### PR TITLE
[FIX] 카카오 로그인 시 콘솔 로그 중복 출력 문제

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../context/authStore';
+import { useEffect } from 'react';
 
 import styled from 'styled-components';
 import "./../assets/styles/variables.css";
@@ -7,7 +8,7 @@ import right from "./../assets/images/right.png";
 
 const Header = () => {
   const navigate = useNavigate();
-  const {user} = useAuthStore();
+  const { user, initialize } = useAuthStore();
 
   const navigateToHome = () => {
     navigate("/");
@@ -16,16 +17,16 @@ const Header = () => {
   const REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
   const REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
 
-  const handleKakaoLogin = () => {
-    if (!REST_API_KEY || !REDIRECT_URI) {
-      console.error('카카오 로그인 설정이 완료되지 않았습니다. 환경 변수를 확인해주세요.');
-      alert('로그인 기능을 준비 중입니다. 잠시만 기다려주세요.');
-      return;
-    }
-    
-    const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+  const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+
+  const handleKakaoLogin = () => {    
     window.location.href = kakaoURL;
   };
+
+  // 컴포넌트 마운트 시 사용자 정보 초기화화
+  useEffect(() => {
+    initialize();
+  }, [initialize]);
 
   return (
     <HeaderWrapper>
@@ -46,7 +47,7 @@ const Header = () => {
           </>
         ) : (
           <>
-            <WelcomeText>{user}님, 반갑습니다.</WelcomeText>
+            <WelcomeText>{user.nickname}님, 반갑습니다.</WelcomeText>
             <LogButton>로그아웃</LogButton>
           </>
         )}

--- a/src/context/authStore.js
+++ b/src/context/authStore.js
@@ -3,4 +3,21 @@ import { create } from "zustand";
 export const useAuthStore = create((set) => ({
   user: null,
 
+  login: (userData) => {
+    localStorage.setItem("userData", JSON.stringify(userData));
+    set({ user: userData });
+  },
+
+  logout: () => {
+    localStorage.removeItem("userData");
+    set({ user: null });
+  },
+
+  initialize: () => {
+    const userData = localStorage.getItem("userData");
+    if (userData) {
+      set({ user: JSON.parse(userData) });
+    }
+  },
+
 }));


### PR DESCRIPTION
## 문제
- 카카오 로그인 시 KakaoRedirect 컴포넌트에서 콘솔 로그가 중복으로 출력되는 문제 발생
- 관련 이슈: #21 
## 해결
- `useRef`를 사용하여 로그인 로직 중복 실행 방지
- `hasExecuted.current` 플래그로 실행 상태 관리

## 변경사항
- `KakaoRedirect.jsx`: 중복 실행 방지 로직 추가
